### PR TITLE
Bug fix: Failed grunt tasks not failing MSBuild target

### DIFF
--- a/Ncapsulate.Grunt/tools/install.ps1
+++ b/Ncapsulate.Grunt/tools/install.ps1
@@ -24,8 +24,7 @@ $nodeRelativePath
 
 <# Install grunt.cmd #>
 $gruntCmd = "@echo off
-$nodeRelativePath\nodejs\node $gruntRelativePath\nodejs\node_modules\grunt-cli\bin\grunt --no-color %*
-@echo on";
+$nodeRelativePath\nodejs\node $gruntRelativePath\nodejs\node_modules\grunt-cli\bin\grunt --no-color %*";
 $gruntLocation = ($projectDirectory + '\grunt.cmd')
 Set-Content $gruntLocation $gruntCmd -Encoding String
 

--- a/Ncapsulate.Node/Tasks/CmdTask.cs
+++ b/Ncapsulate.Node/Tasks/CmdTask.cs
@@ -29,8 +29,7 @@ namespace Ncapsulate.Node.Tasks
 
             var errorString = error.ToString().Trim();
             var outputString = output.ToString().Trim();
-
-            return result == 0 || String.IsNullOrWhiteSpace(errorString) ? outputString : ("ERROR:" + error.ToString().Trim());
+            return result == 0 ? outputString : ("ERROR:" + (String.IsNullOrEmpty(errorString) ? outputString : errorString ));
         }
 
         /// <summary>Invokes a command-line process asynchronously, capturing its output to a string.</summary>


### PR DESCRIPTION
I've been using Ncapsulate today to convert a convoluted gruntfile run from the command line into delicious MSBuild awesomeness.  This library has been a huge help to me today, so thanks!

I encountered two problems while using the library today.  First, when a grunt task fails, [the environment exit code is set to 3](http://gruntjs.com/api/exit-codes), but the CmdTask.ExecAsync class kept returning a 0.  I finally figured out that the final call in grunt.cmd, echo on, was overwriting the %errorlevel% variable.

So the first change in the pull requests just removes that call from the grunt.cmd file generated by the nuget install script.  I don't think it affects anything to remove that line from the batch file.

Once I got that straightened out, the task still wasn't failing because of the line in CmdTask.ExecWithOutputResultAsync that was evaluating the process result.  If the error code was 0 OR the stdError was empty, then it assumed that the process was successful.

I changed it so that if the error code does not equal 0, then it assumes there is an error.  Then it tries to return stdError as the error message, and then stdOut if stdError is empty.  This was the case with grunt, where the exit code was 3 because the task failed, but stdError was empty.

Anyway, I'm not sure if you want to use this or not.  This is my first pull request ever so I'm not sure I'm doing it right.  Let me know if you have questions/comment, and thanks again for such a helpful library.
