### PR TITLE
Uses SETLOCAL in generated npm.cmd

### DIFF
--- a/Ncapsulate.Node/tools/install.ps1
+++ b/Ncapsulate.Node/tools/install.ps1
@@ -19,7 +19,10 @@ Set-Content $nodeLocation $nodeCmd -Encoding String
 
 <# Install npm.cmd #>
 $npmCmd = "@echo off
+setlocal
+set PATH=%~dp0$relativePath\nodejs;%PATH%
 $relativePath\nodejs\npm %*
+endlocal
 @echo on";
 $npmLocation = ($projectDirectory + '\npm.cmd')
 Set-Content $npmLocation $npmCmd -Encoding String


### PR DESCRIPTION
Uses SETLOCAL to add the current node installation to path when executing the npm batch script. Packages running scripts using "node..." will now be executed correctly.

For instance, the module "node-sass" installation was failing because the module has scripts:
`{ "install": "node scripts\install.js", ... }`
but `node` was not recognized as a valid command because it was not in the PATH.

Using SETLOCAL allows to add the local node installation to the path for the duration of the batch execution.
