### PR TITLE
Create bower_components and node_modules if needed on build

### DIFF
--- a/Ncapsulate.Bower/content/App_Build/bower.targets
+++ b/Ncapsulate.Bower/content/App_Build/bower.targets
@@ -9,6 +9,7 @@
   <Target Name="Bower" BeforeTargets="BeforeBuild" Inputs="@(BowerJson)" Outputs="@(BowerLastRun)">
     <BowerInstall />
     <BowerUpdate />
+    <MakeDir Directories="$(MSBuildProjectDirectory)\bower_components" />
     <Delete Files="$(MSBuildProjectDirectory)\bower_components\bower.lastrun" />
     <WriteLinesToFile File="$(MSBuildProjectDirectory)\bower_components\bower.lastrun" Lines="" />
   </Target>

--- a/Ncapsulate.Node/content/App_Build/node.targets
+++ b/Ncapsulate.Node/content/App_Build/node.targets
@@ -9,6 +9,7 @@
   <Target Name="Npm" BeforeTargets="BeforeBuild" Inputs="@(NpmJson)" Outputs="@(NpmLastRun)">
     <NpmInstall />
     <NpmUpdate />
+    <MakeDir Directories="$(MSBuildProjectDirectory)\node_modules" />
     <Delete Files="$(MSBuildProjectDirectory)\node_modules\npm.lastrun" />
     <WriteLinesToFile File="$(MSBuildProjectDirectory)\node_modules\npm.lastrun" Lines="" />
   </Target>

--- a/Ncapsulate.Node/content/App_Build/node.targets
+++ b/Ncapsulate.Node/content/App_Build/node.targets
@@ -6,7 +6,7 @@
     <NpmJson Include="$(MSBuildProjectDirectory)\package.json" />
     <NpmLastRun Include="$(MSBuildProjectDirectory)\node_modules\npm.lastrun" />
   </ItemGroup>
-  <Target Name="Npm" BeforeTargets="BeforeBuild" Inputs="@(NpmJson)" Outputs="@(NpmLastRun)">
+  <Target Name="Npm" Condition="Exists('$(MSBuildProjectDirectory)\package.json')" BeforeTargets="BeforeBuild" Inputs="@(NpmJson)" Outputs="@(NpmLastRun)">
     <NpmInstall />
     <NpmUpdate />
     <MakeDir Directories="$(MSBuildProjectDirectory)\node_modules" />


### PR DESCRIPTION
The WriteLinesToFile task used in bower.targets and node.targets fails
if the bower_components or node_modules folders themselves don't exist.
If any npm or bower packages have already been installed, it's not an
issue, but on an initial install of these NuGet packages (before npm or
bower are used), the solution won't build properly.
