### PR TITLE
tiny change to make error handling more comprehensive

### DIFF
--- a/Ncapsulate.Gulp/Tasks/Gulp.cs
+++ b/Ncapsulate.Gulp/Tasks/Gulp.cs
@@ -54,7 +54,7 @@ namespace Ncapsulate.Gulp.Tasks
 
             var output = Task.WhenAll(ExecWithOutputResultAsync(@"cmd", cmd)).Result.FirstOrDefault();
 
-            if (output.StartsWith("ERROR"))
+            if (output.ToUpper().Contains("ERROR"))
             {
                 this.Log.LogError("gulp run - error: " + output);
                 return false;


### PR DESCRIPTION
I made this change because the plugin wasn't picking up errors from gulp (specifically gulp-eslint)
